### PR TITLE
The order was wrong resulting in the weird behaviour

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -10,6 +10,11 @@
   <%= @post.body %>
 </p>
 
+
+
+<h2>Comments</h2>
+<%= render @post.comments %>
+
 <h2>Add a comment:</h2>
 <%= form_for([@post, @post.comments.build]) do |f| %>
   <p>
@@ -24,11 +29,6 @@
     <%= f.submit %>
   </p>
 <% end %>
-
-<h2>Comments</h2>
-<%= render @post.comments %>
-
- 
 
 
 <%= link_to 'Edit', edit_post_path(@post) %> |


### PR DESCRIPTION
As you can see I changed the order in the template.

By doing this 

```
 <%= form_for([@post, @post.comments.build]) do |f| %>
```

before

```
<%= render @post.comments %>
```

The first piece of code creates a collection of comments in memory for this post. Similar to how you use the following snippet to build a form to create a new post.

```
@post = Post.new
```

After that render @post.comments will try to print all those comments on the page. However the comment created by _@post.comments.build_ does not exists in the database and therefore does not have an id. This results in the error you saw earlier.
